### PR TITLE
Reduced supported API level + convenience script

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -92,16 +92,16 @@ android.permissions = INTERNET,BLUETOOTH,BLUETOOTH_ADMIN,ACCESS_FINE_LOCATION,AC
 android.api = 30
 
 # (int) Minimum API your APK will support.
-android.minapi = 28
+android.minapi = 26
 
 # (int) Android SDK version to use
-android.sdk = 28
+android.sdk = 26
 
 # (str) Android NDK version to use
 #android.ndk = 19b
 
 # (int) Android NDK API to use. This is the minimum API your app will support, it should usually match android.minapi.
-android.ndk_api = 28
+android.ndk_api = 26
 
 # (bool) Use --private data storage (True) or --dir public storage (False)
 #android.private_storage = True

--- a/copy-styles.sh
+++ b/copy-styles.sh
@@ -1,0 +1,2 @@
+mkdir -p .buildozer/android/platform/build-armeabi-v7a/dists/wearvesc/src/main/res/values
+cp style/styles.xml .buildozer/android/platform/build-armeabi-v7a/dists/wearvesc/src/main/res/values/styles.xml


### PR DESCRIPTION
Reduced supported API level to 26 both on android SDK and NDK in order to run the app on older devices. Had to delete the .buildozer folder for it to build, though.

Tested on a fully updated Ticwatch E (Android 8.0.0):

![photo_2021-10-22_23-54-19](https://user-images.githubusercontent.com/5404052/138527157-201d0db3-33a9-495c-b950-aaedd133b477.jpg)
![photo_2021-10-22_23-54-53](https://user-images.githubusercontent.com/5404052/138527181-311cc7f4-2449-4e44-956f-c328449ff23d.jpg)

Also included a convenience script to copy styles.xml to the correct folder, in order to circunvent buildozer limitation.

----------------

If you're interested in support for this older devices, please count me in for testing! Love the app, works like a charm. Keep up the good work!

